### PR TITLE
Fix: Handle global_percentage being None and default to 0

### DIFF
--- a/src/achievements/admin.py
+++ b/src/achievements/admin.py
@@ -15,4 +15,4 @@ class AchievementAdmin(admin.ModelAdmin):
 
     @admin.display(description="Percentage")
     def percentage(self, obj):
-        return f"{obj.global_percentage:05.2f}"
+        return f"{obj.global_percentage:05.2f}%" if obj.global_percentage is not None else "-"

--- a/src/games/schema/games.py
+++ b/src/games/schema/games.py
@@ -17,6 +17,10 @@ class AchievementType(DjangoObjectType):
         model = Achievement
         fields = "__all__"
 
+    def resolve_global_percentage(root, info):
+        """Handle rare situations where the global achievement percentages for a game have not been fetched yet."""
+        return root.global_percentage or 0
+
 
 class Query(graphene.ObjectType):
     game = graphene.Field(GameType, id=graphene.Int(), name=graphene.String())

--- a/src/players/schema/players.py
+++ b/src/players/schema/players.py
@@ -40,7 +40,7 @@ def transform_unlocked_achievement(achievement: PlayerUnlockedAchievement, *, re
         "description": achievement.achievement.description,
         "icon_url": achievement.achievement.icon_url,
         "icon_gray_url": achievement.achievement.icon_gray_url,
-        "global_percentage": achievement.achievement.global_percentage,
+        "global_percentage": achievement.achievement.global_percentage or 0,
         "unlocked": achievement.datetime if achievement.datetime is not None else None,
     }
 
@@ -345,7 +345,7 @@ class Query(graphene.ObjectType):
                 unlocked_achievements = unlocked_achievements.select_related("achievement")
                 indexed_unlocked_achievements = {obj.achievement.name: obj for obj in unlocked_achievements}
 
-                def create_achievement(achievement):
+                def create_achievement(achievement: Achievement):
                     unlocked_achievement = (
                         indexed_unlocked_achievements[achievement.name]
                         if (achievement.name in indexed_unlocked_achievements)
@@ -359,7 +359,7 @@ class Query(graphene.ObjectType):
                         "description": achievement.description,
                         "icon_url": achievement.icon_url,
                         "icon_gray_url": achievement.icon_gray_url,
-                        "global_percentage": achievement.global_percentage,
+                        "global_percentage": achievement.global_percentage or 0,
                         "unlocked": unlocked_achievement.datetime if unlocked_achievement else None,
                     }
 


### PR DESCRIPTION
It is possible (mainly due to another bug), but still possible, that a game will have achievements but all the global_percentage values will be null.

Might have been better if they defaulted to 0.

However, since it's technically possible for a game to synchronize, but not it's achievement percentages, it makes sense for the API code to handle None and return 0 through the API response.