### PR TITLE
Fix: Add missing property to PlayerOwnedGameResponse

### DIFF
--- a/src/players/responsedata.py
+++ b/src/players/responsedata.py
@@ -43,6 +43,7 @@ class PlayerOwnedGameResponse:
     playtime_windows_forever: int = 0
     playtime_mac_forever: int = 0
     playtime_linux_forever: int = 0
+    playtime_deck_forever: int = 0
     rtime_last_played: Optional[int] = None
     playtime_disconnected: int = 0
     has_leaderboards: Optional[bool] = None


### PR DESCRIPTION
Add 'playtime_deck_forever' to PlayerOwnedGameResponse, causing response parsing failure.