### PR TITLE
Fix: Update Player completion percentage when Game Achievement count changes

### DIFF
--- a/src/games/admin.py
+++ b/src/games/admin.py
@@ -17,8 +17,8 @@ class GameAdmin(admin.ModelAdmin):
         return not obj.resynchronization_required
 
     @admin.display(description="Achievements")
-    def achievements(self, obj):
-        return Achievement.objects.filter(game=obj).count()
+    def achievements(self, obj: Game):
+        return obj.get_achievements().count()
 
 
 @admin.register(Achievement)

--- a/src/games/models.py
+++ b/src/games/models.py
@@ -42,3 +42,6 @@ class Game(models.Model):
 
     def has_achievements(self):
         return Achievement.objects.filter(game_id=self.id).count() > 0
+
+    def get_achievements(self):
+        return Achievement.objects.filter(game_id=self.id)

--- a/src/games/service.py
+++ b/src/games/service.py
@@ -5,6 +5,7 @@ from django.utils import timezone
 from .responsedata import GameAchievementResponse
 from .models import Game, Achievement
 from .steam import load_game_schema, load_game_achievement_percentages
+from players.models import PlayerOwnedGame
 
 
 def query_game(identity: Union[int, str]) -> Optional[Game]:
@@ -32,23 +33,36 @@ def load_game(identity: Union[int, str]) -> Game:
     return game
 
 
-def resynchronize_game(game: Game, *, resynchronize_achievements: bool = True) -> bool:
+def resynchronize_game(game: Game) -> bool:
     ok = False
 
     try:
         logger.debug(f"Resynchronizing game '{game.name}' ({game.id})")
+
+        original_achievement_count = len(game.get_achievements())
+
         resynchronize_game_schema(game)
 
-        if resynchronize_achievements:
-            if game.has_achievements():
-                resynchronize_game_achievements(game)
-            else:
-                logger.debug(f"Game '{game.name}' does not have any achievements")
+        updated_achievement_count = len(game.get_achievements())
+
+        # The achievement percentages can change, even if the number of achievements remain the same
+        if updated_achievement_count > 0:
+            resynchronize_game_achievement_percentages(game)
+        else:
+            logger.debug(f"Game '{game.name}' does not have any achievements")
 
         # Resynchronization completed successful
         game.resynchronized = timezone.now()
         game.resynchronization_required = False
         game.save()
+
+        # If the number of achievements have changes, some players may no longer have all achievements unlocked
+        if original_achievement_count != updated_achievement_count:
+            owned_games = PlayerOwnedGame.objects.filter(game=game)
+            for owned_game in owned_games:
+                owned_game.resynchronization_required = True
+                owned_game.save(update_fields=["resynchronization_required"])
+
         ok = True
     except Exception:
         logger.exception(f"Failed to resynchronize game '{game.name}'")
@@ -57,6 +71,7 @@ def resynchronize_game(game: Game, *, resynchronize_achievements: bool = True) -
 
 
 def resynchronize_game_schema(game: Game) -> bool:
+    """Updates the db game with data from Steam, including game achievements"""
     ok = False
 
     schema = load_game_schema(game.id)
@@ -97,7 +112,7 @@ def save_achievements(game: Game, achievements: List[GameAchievementResponse]) -
         )
 
 
-def resynchronize_game_achievements(game: Game) -> bool:
+def resynchronize_game_achievement_percentages(game: Game) -> bool:
     ok = False
     logger.debug(f"Loading global achievement percentages for game '{game.name}' ({game.id})")
     achievement_percentages = load_game_achievement_percentages(game.id)

--- a/src/players/service.py
+++ b/src/players/service.py
@@ -99,14 +99,28 @@ def resynchronize_player(player: Player) -> bool:
     ok = False
 
     try:
-        ok = resynchronize_player_profile(player)
-        ok &= resynchronize_player_games(player)
-        ok &= resynchronize_recent_player_game_achievements(player)
+        error = False
+        if not resynchronize_player_profile(player):
+            logger.error(f"Failed to resynchronize player {player.name} profile")
+            error = True
 
-        if ok is True:
+        if not resynchronize_player_games(player):
+            logger.error(f"Failed to resynchronize player {player.name} games")
+            error = True
+
+        if not resynchronize_recent_player_game_achievements(player):
+            logger.error(f"Failed to resynchronize player {player.name} game achievements")
+            error = True
+
+        if not resynchronize_player_owned_games(player, required_only=True):
+            logger.error(f"Failed to resynchronize player {player.name} game achievements")
+            error = True
+
+        if not error:
             player.resynchronized = timezone.now()
             player.resynchronization_required = False
             player.save()
+            ok = True
     except Exception:
         logger.exception(f"Failed to resynchronize player '{player.name}'")
 
@@ -148,6 +162,7 @@ def should_save_playtime_record(playtime: PlayerGamePlaytime, new_playtime: int,
 
 
 def resynchronize_player_games(player: Player) -> bool:
+    """Resynchronize player games from Steam data"""
     owned_games = get_owned_games(player.id, player.api_key)
     logger.info(f"Player {player.name} has {len(owned_games)} games")
 
@@ -205,6 +220,8 @@ def resynchronize_player_games(player: Player) -> bool:
         if last_played_time is not None:
             changes["last_played"] = last_played_time
 
+        changes["resynchronization_required"] = False
+
         owned_game_instance, owned_game_created = PlayerOwnedGame.objects.update_or_create(
             game=game_instance,
             player=player,
@@ -214,17 +231,27 @@ def resynchronize_player_games(player: Player) -> bool:
     return len(owned_games) > 0
 
 
-def resynchronize_all_player_game_achievements(player: Player) -> bool:
-    """Resynchronize player achievements for recently played games"""
+def resynchronize_player_owned_games(player: Player, *, required_only=False) -> bool:
+    """Resynchronize player owned games (from the database)"""
     ok = False
 
-    player_games = PlayerOwnedGame.objects.filter(player=player)
-    logger.debug(f"Resynchronizing achievements for {len(player_games)} games for {player.name}")
+    filter = {}
+    if required_only:
+        filter = {"resynchronization_required": True}
 
-    for record in player_games:
-        game = record.game
-        resynchronize_game(game)
-        resynchronize_player_achievements_for_game(player, game)
+    try:
+        owned_games = PlayerOwnedGame.objects.filter(player=player, **filter)
+        logger.debug(f"Resynchronizing {len(owned_games)} owned games for {player.name}")
+
+        for record in owned_games:
+            game = record.game
+            resynchronize_game(game)
+            resynchronize_player_achievements_for_game(player, game)
+
+            record.resynchronization_required = False
+            record.save(update_fields=["resynchronization_required"])
+    except Exception:
+        logger.exception(f"Failed to resynchronize player '{player.name}'")
 
     return ok
 
@@ -249,8 +276,10 @@ def resynchronize_recent_player_game_achievements(player: Player) -> bool:
     return ok
 
 
-def resynchronize_player_achievements_for_game(player: Player, game: Game):
-    game_achievements = game_achievements = Achievement.objects.filter(game=game.id)
+def resynchronize_player_achievements_for_game(player: Player, game: Game) -> bool:
+    ok = False
+
+    game_achievements = game.get_achievements()
     logger.debug(f"Collecting player {player.name} achievements for '{game.name}'")
     player_achievements = get_player_achievements_for_game(player.id, game.id)
     unlocked = list(filter(lambda achievement: achievement.achieved == 1, player_achievements))
@@ -331,5 +360,6 @@ def resynchronize_player_achievements_for_game(player: Player, game: Game):
             "resynchronization_required",
         ]
     )
+    ok = True
 
-    return True
+    return ok


### PR DESCRIPTION
Occasionally games get new achievements. The scheduled resynchronisation of a game will update the achievements, but did not update the payers completion percentage on the Player Owned Game record.

Now, the Player Owned Game record will be marked for resynchronization and when the player is resynchronized, those records will be updated.