### PR TITLE
Chore: Update handling of game achievement percentages

### DIFF
--- a/src/achievementchaser/steam.py
+++ b/src/achievementchaser/steam.py
@@ -19,7 +19,7 @@ def _get_api_key():
 
 
 def mask_key(url: str):
-    return url.replace(_get_api_key(), "################################") if settings.DEBUG else url
+    return url.replace(_get_api_key(), "################################") if not settings.DEBUG else url
 
 
 def _request(url: str, *, params: Any) -> Response:
@@ -34,16 +34,8 @@ def _request(url: str, *, params: Any) -> Response:
     return req.ok, req.json() if "application/json" in req.headers["Content-Type"] else None
 
 
-def request(path: str, query: dict, response_data_key: str) -> Tuple[bool, Optional[dict]]:
-    # Always add the API key and response format
-    query_parameters = {
-        "key": _get_api_key(),
-        "format": "json",
-    }
-    query_parameters.update(query)
-
-    if "key" not in query_parameters or not query_parameters["key"]:
-        raise KeyError("Steam API 'key' missing from query parameters")
+def request(path: str, query: dict, response_data_key: str, key: bool = True) -> Tuple[bool, Optional[dict]]:
+    query_parameters = {**({"key": _get_api_key()} if key else {}), "format": "json", **query}
 
     ok, response_json = _request(f"https://{STEAM_API_URL}/{path}", params=query_parameters)
 

--- a/src/games/responsedata.py
+++ b/src/games/responsedata.py
@@ -68,4 +68,6 @@ class AchievementPercentagesResponse:
         self.achievements = []
 
         for achievement in achievements:
+            # Steam is returning the percentage as a string
+            achievement["percent"] = float(achievement["percent"])
             self.achievements.append(AchievementPercentageResponse(**achievement))

--- a/src/games/steam.py
+++ b/src/games/steam.py
@@ -32,6 +32,7 @@ def load_game_achievement_percentages(id: int) -> Optional[AchievementPercentage
                 "gameid": id,
             },
             "achievementpercentages",
+            key=False,
         )
 
         if ok and response and "achievements" in response:


### PR DESCRIPTION
Steam API appears to have changed `GetGlobalAchievementPercentagesForApp` to return the percentage as a string value, instead of a float value. While this was parsed into the response class successfully, when it came to calculating a games difficulty the calculation failed.

In the assumption the value wont be anything but a float (as a string), this change just casts the value to a float.